### PR TITLE
feat: adds styling to contributors page, adds build:sass task

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "HacktoberFest2019",
   "license": "MIT",
   "scripts": {
+    "build:sass": "node-sass public/css/styles.scss public/css/styles.css",
     "start": "node src/app.js",
     "dev": "nodemon src/app.js -e js.hbs",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,6 +15,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "hbs": "^4.0.5",
+    "node-sass": "^4.12.0",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,16 +1,28 @@
-.contributors-container .box-item {
-  position: relative;
+.contributors__container {
+  display: flex;
+  justify-content: center; }
+
+.contributors__list {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: center; }
+  @media (min-width: 1200px) {
+    .contributors__list {
+      max-width: 1200px; } }
+
+.contributors__person {
+  padding: 1rem; }
+
+.contributors__image {
+  max-width: 150px;
+  border-radius: 50%;
+  border: 2px solid #ee6e73; }
+  @media (min-width: 768px) {
+    .contributors__image {
+      max-width: 200px; } }
+
+.contributors__link {
   display: block;
-  color: #444;
-  font-weight: 600;
-  width: 100%;
-  cursor: pointer;
-  border-radius: 0.4rem;
-  padding: 15px 8px 15px 70px;
-  margin: 10px;
-  font-size: 1rem;
-  text-overflow: ellipsis;
-  overflow-x: hidden;
-  white-space: nowrap;
-}
-/*# sourceMappingURL=styles.css.map */
+  text-align: center; }
+  .contributors__link:hover {
+    text-decoration: underline; }

--- a/public/css/styles.scss
+++ b/public/css/styles.scss
@@ -25,28 +25,49 @@ p {
   }
 }
 
-
+// Variables (will probably be updated when style guide is complete)
+$primary-color: #ee6e73;
 
 // ****************************************
-// Contributuers Page
-.contributors-container {
-  .box-item {
-    position: relative;
-    display: block;
-    color: #444;
-    font-weight: 600;
-    width: 100%;
-    cursor: pointer;
-    border-radius: 0.4rem;
-    padding: 15px 8px 15px 70px;
-    margin: 10px;
-    font-size: 1rem;
-    text-overflow: ellipsis;
-    overflow-x: hidden;
-    white-space: nowrap;
+// Contributors Page
+
+.contributors {
+  &__container {
+    display: flex;
+    justify-content: center;
   }
 
-  @media (max-width: 768px) {
+  &__list {
+    display: flex;
+    flex-flow: wrap;
+    justify-content: center;
 
+    // To prevent too many in a row across
+    @media (min-width: 1200px) {
+      max-width: 1200px;
+    }
+  }
+
+  &__person {
+    padding: 1rem;
+  }
+  
+  &__image {
+    max-width: 150px;
+    border-radius: 50%;
+    border: 2px solid $primary-color;
+
+    @media (min-width: 768px) {
+      max-width: 200px;
+    }
+  }
+
+  &__link {
+    display: block;
+    text-align: center;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/templates/views/contributors.hbs
+++ b/templates/views/contributors.hbs
@@ -13,16 +13,18 @@
     <header>
         {{>header}}
     </header>
-    <section class="rename">
-        <div class="container">
-            <ul>
-                <li>
-                    <a class="box-item" href="https://github.com/3daddict">Mike Salvati</a>
 
+    <section class="contributors">
+        <div class="contributors__container">
+            <ul class="contributors__list">
+                <li class="contributors__person">
+                    <img class="contributors__image" src="https://avatars3.githubusercontent.com/u/29803478" alt="Mike Salvati">
+                    <a class="contributors__link" href="https://github.com/3daddict">Mike Salvati</a>
                 </li>
             </ul>
         </div>
     </section>
+
     <footer>
         {{>footer}}
     </footer>


### PR DESCRIPTION
The Pull Request resolves Issue #14 

Description:

- Updates markup with new classnames following the BEM naming conventions
- Adds image (currently just pulled from GitHub, but can be added from anywhere)
- Adds styling to Contributors page
  - Uses flexbox so any number of contributors can be added, and the page will reflow based on screen size and amount of contributors. The max that will ever be shown across is 5.
- Adds `build:sass` task and `node_sass` to allow users to compile Sass
  - _Note:_ This was added so a developer can run `npm run build:sass` to compile their Sass -> CSS. It only compiles the main `styles.scss` file to `styles.css`. If more files are added or need compiled, this will need adjusted.

Screenshots below of different screen sizes and amount of maintainers.

<img width="1201" alt="HacktoberFest_2019___Contributors-1200px-1up" src="https://user-images.githubusercontent.com/35239154/66086224-67e1d880-e541-11e9-8133-692be82497dc.png">
<img width="1198" alt="HacktoberFest_2019___Contributors-1200px" src="https://user-images.githubusercontent.com/35239154/66086225-67e1d880-e541-11e9-862a-b4ccd9ac67ab.png">
<img width="768" alt="HacktoberFest_2019___Contributors-iPad-1up" src="https://user-images.githubusercontent.com/35239154/66086226-67e1d880-e541-11e9-8c36-75a8c3c3d419.png">
<img width="768" alt="HacktoberFest_2019___Contributors-iPad" src="https://user-images.githubusercontent.com/35239154/66086227-67e1d880-e541-11e9-80c1-1b37ae89a3b3.png">
<img width="372" alt="HacktoberFest_2019___Contributors-iPhoneX-1up" src="https://user-images.githubusercontent.com/35239154/66086228-67e1d880-e541-11e9-9e97-cacb8f32cb45.png">
<img width="372" alt="HacktoberFest_2019___Contributors-iPhoneX" src="https://user-images.githubusercontent.com/35239154/66086229-67e1d880-e541-11e9-8a59-a048a836592b.png">
